### PR TITLE
Stubbed out Cars196DataLoader implementation

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -3,3 +3,7 @@ data_dir: "/data/cars_196"
 annotations_path: "/data/cars_196/cars_annos.mat"
 
 log_path: "/tmp/logs/log.html"
+
+train:
+    categories_per_batch: 32
+    samples_per_category: 4

--- a/net/data.py
+++ b/net/data.py
@@ -2,6 +2,11 @@
 Module with data related code
 """
 
+import collections
+import os
+import random
+
+import cv2
 import scipy.io
 
 import net.constants
@@ -30,34 +35,110 @@ class Cars196Annotation:
         self.dataset_mode = net.constants.DatasetMode(annotation_matrix[-1])
 
 
+def get_cars_196_annotations_map(annotations_path, dataset_mode):
+    """
+    Read cars 196 annotations into a category_id: list of Cars196Annotation map and return it
+
+    :param annotations_path: path to annotations data
+    :type annotations_path: str
+    :param dataset_mode: net.constants.DatasetMode instance,
+    indicates annotations for which dataset (train/validation) should be loaded
+    :return: map {category_id: list of Cars196Annotation}
+    :rtype: dict
+    """
+
+    annotations_data_map = scipy.io.loadmat(annotations_path)
+
+    annotations_matrices = annotations_data_map["annotations"].flatten()
+    categories_names = annotations_data_map["class_names"].flatten()
+
+    # Get a list of annotations for specified dataset mode
+    annotations = [
+        Cars196Annotation(
+            annotation_matrix=annotation_matrix,
+            categories_names=categories_names) for annotation_matrix in annotations_matrices
+        if net.constants.DatasetMode(annotation_matrix[-1][0][0]) == dataset_mode]
+
+    categories_ids_samples_map = collections.defaultdict(list)
+
+    # Move annotations into categories_ids: annotations map
+    for annotation in annotations:
+
+        categories_ids_samples_map[annotation.category_id].append(annotation)
+
+    return categories_ids_samples_map
+
+
 class Cars196DataLoader:
     """
     Data loader class for cars 196 dataset
     """
 
-    def __init__(self, data_dir, annotations_path, dataset_mode):
+    def __init__(self, data_dir, annotations_path, dataset_mode, categories_per_batch, samples_per_category):
         """
         Constructor
 
         :param data_dir: path to base data directory
         :type images_dir: str
-        :param annotations_path: path to annotation sdata
+        :param annotations_path: path to annotations data
         :type annotations_path: str
         :param dataset_mode: net.constants.DatasetMode instance,
         indicates which dataset (train/validation) loader should load
+        :param categories_per_batch: number of categories in each batch
+        :type categories_per_batch: int
+        :param samples_per_category: number of samples for a category in a batch
+        :type samples_per_category: int
         """
 
-        annotations_data_map = scipy.io.loadmat(annotations_path)
-
-        annotations_matrices = annotations_data_map["annotations"].flatten()
-        categories_names = annotations_data_map["class_names"].flatten()
-
-        # Get a list of annotations for specified dataset mode
-        self.annotations = [
-            Cars196Annotation(
-                annotation_matrix=annotation_matrix,
-                categories_names=categories_names) for annotation_matrix in annotations_matrices
-            if net.constants.DatasetMode(annotation_matrix[-1][0][0]) == dataset_mode]
+        self.categories_ids_samples_map = get_cars_196_annotations_map(
+            annotations_path=annotations_path,
+            dataset_mode=dataset_mode)
 
         self.data_dir = data_dir
-        self.dataset_model = dataset_mode
+
+        self.categories_per_batch = categories_per_batch
+        self.samples_per_category = samples_per_category
+
+    def __iter__(self):
+
+        while True:
+
+            categories_samples_batch = self._get_categories_samples_batch()
+
+            categories_images_batch = collections.defaultdict(list)
+            categories_labels_batch = collections.defaultdict(list)
+
+            for category, samples in categories_samples_batch.items():
+
+                for sample in samples:
+
+                    image = cv2.imread(os.path.join(self.data_dir, sample.filename))
+
+                    categories_images_batch[category].append(image)
+                    categories_labels_batch[category].append(sample.category_id)
+
+            yield categories_images_batch, categories_labels_batch
+
+    def _get_categories_samples_batch(self):
+        """
+        Draw a batch of categories samples - k categories, p samples for each
+        :return: dictionary {category_id: list of Cars196Annotation instances}
+        """
+
+        # Select categories to draw from
+        categories_to_draw = random.sample(
+            population=self.categories_ids_samples_map.keys(),
+            k=self.categories_per_batch)
+
+        batch_map = {}
+
+        for category in categories_to_draw:
+
+            samples_to_draw = random.sample(
+                population=self.categories_ids_samples_map[category],
+                k=self.samples_per_category
+            )
+
+            batch_map[category] = samples_to_draw
+
+        return batch_map

--- a/net/invoke/ml.py
+++ b/net/invoke/ml.py
@@ -14,6 +14,8 @@ def train(_context, config_path):
     :param config_path: str, path to configuration file
     """
 
+    import tqdm
+
     import net.constants
     import net.data
     import net.utilities
@@ -23,8 +25,19 @@ def train(_context, config_path):
     training_data_loader = net.data.Cars196DataLoader(
         data_dir=config["data_dir"],
         annotations_path=config["annotations_path"],
-        dataset_mode=net.constants.DatasetMode.TRAINING
+        dataset_mode=net.constants.DatasetMode.TRAINING,
+        categories_per_batch=config["train"]["categories_per_batch"],
+        samples_per_category=config["train"]["samples_per_category"]
     )
 
     print(training_data_loader)
-    print(len(training_data_loader.annotations))
+
+    iterator = iter(training_data_loader)
+
+    for _ in tqdm.tqdm(range(4)):
+
+        categories_images_batch, categories_labels_batch = next(iterator)
+
+        print(categories_images_batch.keys())
+        print(categories_labels_batch.keys())
+        print()


### PR DESCRIPTION
It returns batches of categories_images and categories_labels, but images are still in raw size/format.
Also there is no coordination of samples across draws - so two successive draws might return overlapping samples, etc.